### PR TITLE
Add PoC of commit count image

### DIFF
--- a/git-contrib-graph_test.go
+++ b/git-contrib-graph_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestCorrectSumTotalsChangesByAuthor(t *testing.T) {
 	convey.Convey("Given two day with changes of a author", t, func() {
-		days := make(map[string]Stats)
-		changesFirstDay := Stats{Addition: 10, Commits: 2, Deletion: 3, Files: 2}
-		changesSecondDay := Stats{Addition: 2, Commits: 1, Deletion: 4, Files: 1}
+		days := make(map[string]stats)
+		changesFirstDay := stats{Addition: 10, Commits: 2, Deletion: 3, Files: 2}
+		changesSecondDay := stats{Addition: 2, Commits: 1, Deletion: 4, Files: 1}
 
 		days["2018-12-10"] = changesFirstDay
 		days["2018-12-11"] = changesSecondDay


### PR DESCRIPTION
This proof of concepts shows the creation
of line graphs depicting the number of commits
of an author per active day.

Upon using the command line flag --img,
one graph exported to a .png file per author will be created.

Note that the addition adds the dependence to the following go package:
* github.com/wcharczuk/go-chart

Known limitations:
* If an author has only one single day of contributions, the graph won't display
* The y axis shows float numbers even though commit count is a discrete value
* It doesn't look very nice

Signed-off-by: David <david@isan.engineer>